### PR TITLE
MFP2-2872: SVG Redundant Load Polarity Fix

### DIFF
--- a/packages/gerber-to-svg/lib/plotter-to-svg.js
+++ b/packages/gerber-to-svg/lib/plotter-to-svg.js
@@ -47,6 +47,7 @@ var PlotterToSvg = function(id, attributes, createElement, objectMode) {
   this._lastLayer = 0
   this._blockCount = 0
   this._blockCount = 0
+  this._polarity = 'dark'
 
   this._element = createElement
 }
@@ -133,18 +134,25 @@ PlotterToSvg.prototype._handleNewPolarity = function(polarity, box) {
     return this._finishBlockLayer()
   }
 
-  this._clearCount =
-    polarity === 'clear' ? this._clearCount + 1 : this._clearCount
-  var maskId = this.id + '_clear-' + this._clearCount
+  // Check if polarity actually changed, ignore redundent gerber polarity commands 
+  // that do not change the polarity.
+
+  if (this._polarity === 'dark') { 
+    this._clearCount =
+      polarity === 'clear' ? this._clearCount + 1 : this._clearCount
+    var maskId = this.id + '_clear-' + this._clearCount
 
   // if clear polarity, wrap the layer and start a mask
-  if (polarity === 'clear') {
-    this.layer = [maskLayer(maskId, this.layer, this._element)]
-    this._maskId = maskId
-    this._maskBox = box.slice(0)
-  } else {
-    // else, finish the mask and add it to the defs
-    this._finishClearLayer(box)
+    if (polarity === 'clear') {
+      this._polarity = 'clear'
+      this.layer = [maskLayer(maskId, this.layer, this._element)]
+      this._maskId = maskId
+      this._maskBox = box.slice(0)
+    } else {
+      // else, finish the mask and add it to the defs
+      self._polarity = 'dark'
+      this._finishClearLayer(box)
+    }
   }
 }
 

--- a/packages/gerber-to-svg/package.json
+++ b/packages/gerber-to-svg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gerber-to-svg",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "Render individual Gerber / NC drill files as SVGs",
   "main": "index.js",
   "types": "index.d.ts",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/tracespace/tracespace.git",
+    "url": "git://github.com/MacroFab/tracespace.git",
     "directory": "packages/gerber-to-svg"
   },
   "keywords": [


### PR DESCRIPTION
Simple fix that correctly keeps track of the polarity state and ignores redundant polarity changes.  

Related pull request: https://github.com/MacroFab/s3-gerber-to-svg/pull/51

Ticket: https://macrofab.atlassian.net/browse/MFP2-2872